### PR TITLE
Update site to a pre-registration version of the ACCFI 2018 site

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,7 +4,7 @@
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 
-	<title>{% if page.title %}{{ page.title }} | {% endif %}ACCFI 2016</title>
+	<title>{% if page.title %}{{ page.title }} | {% endif %}ACCFI 2018</title>
 
 	<meta name="author" content="Agile Coaching Camp Finland">  
   	<meta property="og:title" content="{% if page.title %}{{ page.title }} | {% endif %}Agile Coaching Camp Finland" />

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,7 +7,7 @@
 	<title>{% if page.title %}{{ page.title }} | {% endif %}ACCFI 2018</title>
 
 	<meta name="author" content="Agile Coaching Camp Finland">  
-  	<meta property="og:title" content="{% if page.title %}{{ page.title }} | {% endif %}Agile Coaching Camp Finland" />
+  	<meta property="og:title" content="{% if page.title %}{{ page.title }} | {% endif %}Agile Coach Camp Finland" />
   	<meta property="og:site_name" content="Agile Coaching Camp Finland" />
   
     <meta name="description" content=""/>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,7 +1,7 @@
 <nav id="branding" class="navbar navbar-default navbar-fixed-top hidden-xs">
   <div class="container-fluid text-center ">
 	  <!-- Brand and toggle get grouped for better mobile display -->
-	  <h1>Agile Coaching Camp Finland</h1>
+	  <h1>Agile Coach Camp Finland</h1>
 	  <h2>September 7, 8 & 9 in a beautiful scenic location near Helsinki, Finland (to be unveiled)</h2>
   </div><!-- /.container-fluid -->
 </nav>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -2,14 +2,14 @@
   <div class="container-fluid text-center ">
 	  <!-- Brand and toggle get grouped for better mobile display -->
 	  <h1>Agile Coaching Camp Finland</h1>
-	  <h2>May 20, 21 & 22 in <a href="https://www.google.fi/maps/place/Herrankukkaro/@60.3363156,21.9488919,13z/data=!4m5!3m4!1s0x468b80d0f97b73a3:0xb7a4d80c40bcaa56!8m2!3d60.3363156!4d21.9839162">Herrankukkaro, Naantali</a></h2>
+	  <h2>September 7, 8 & 9 in a beautiful scenic location near Helsinki, Finland (to be unveiled)</h2>
   </div><!-- /.container-fluid -->
 </nav>
 <nav id="branding" class="navbar navbar-default visible-xs">
   <div class="container-fluid text-center visible-xs">
 	  <!-- Brand and toggle get grouped for better mobile display -->
 	  <h1>ACCFI</h1>
-	  <h2><time datetime"2016-05-20">20.</time>-<time datetime="2016-05-22">22.5.2016</time> Herrankukkaro, Naantali</h2>
+	  <h2><time datetime"2016-05-20">7.</time>-<time datetime="2016-05-22">9.8.2018</time> Near Helsinki</h2>
   </div><!-- /.container-fluid -->
 </nav>
 

--- a/_includes/site-header.html
+++ b/_includes/site-header.html
@@ -1,6 +1,6 @@
 
 <header class="site-header row text-center">
-<h3 class="text-center">The 1st ever Agile Coaching Camp Finland will take place on a weekend in May, 20.-22.5.2016.</h3>
+<h3 class="text-center">The 2nd Agile Coaching Camp Finland will take place on a weekend in September, 7.-9.9.2018.</h3>
 </header>
 
 <div class="hero-unit frontpage"></div>

--- a/_includes/site-header.html
+++ b/_includes/site-header.html
@@ -1,6 +1,6 @@
 
 <header class="site-header row text-center">
-<h3 class="text-center">The 2nd Agile Coaching Camp Finland will take place on a weekend in September, 7.-9.9.2018.</h3>
+<h3 class="text-center">The 2nd Agile Coach Camp Finland will take place on a weekend in September, 7.-9.9.2018.</h3>
 </header>
 
 <div class="hero-unit frontpage"></div>

--- a/_organizers/aki-salmi.md
+++ b/_organizers/aki-salmi.md
@@ -1,9 +1,0 @@
----
-name: Aki Salmi
-title: Organizer
-location: Finland
-id: aki-salmi
-twitter: rinkkasatiainen
-image: https://pbs.twimg.com/profile_images/1877737374/20110907at09-16-47.jpg
-email: aki.salmi@iki.fi
----

--- a/_organizers/daniel-wellner.md
+++ b/_organizers/daniel-wellner.md
@@ -1,0 +1,9 @@
+---
+name: Daniel Wellner
+title: Organizer
+location: Finland
+id: Daniel Wellner
+twitter: dmwellner
+image: https://pbs.twimg.com/profile_images/587683024403206144/dvBzcNbw.jpg
+email:
+---

--- a/_organizers/katja-zorina.md
+++ b/_organizers/katja-zorina.md
@@ -1,9 +1,0 @@
----
-name: Katja Zorina
-title: Organizer
-location: Finland
-id: katja-zorina
-twitter: katjazorina
-image: https://pbs.twimg.com/profile_images/558340091350110208/y12PoAXb.jpeg
-email:
----

--- a/_organizers/kjell-lauren.md
+++ b/_organizers/kjell-lauren.md
@@ -1,9 +1,0 @@
----
-name: Kjell Lauren
-title: Organizer
-location: Finland
-id: kjell-lauren
-twitter: klauren69
-image: https://pbs.twimg.com/profile_images/1216180573/photo.jpg
-email:
----

--- a/_organizers/llewellyn-falco.md
+++ b/_organizers/llewellyn-falco.md
@@ -1,9 +1,0 @@
----
-name: Llewellyn Falco
-title: Organizer
-location: USA / Finland
-id: llewellyn-falco
-twitter: LlewellynFalco
-image: https://pbs.twimg.com/profile_images/1837642393/twitter_profile.png
-email: isidore@setgame.com
----

--- a/_organizers/maaret-pyhajarvi.md
+++ b/_organizers/maaret-pyhajarvi.md
@@ -1,9 +1,0 @@
----
-name: Maaret Pyhäjärvi
-title: Organizer
-location: Finland
-id: maaret-pyhajarvi
-twitter: maaretp
-image: https://pbs.twimg.com/profile_images/629062251152961536/kumhZ5lm_400x400.jpg
-email: maaret.pyhajarvi@iki.fi
----

--- a/_organizers/ville-manninen.md
+++ b/_organizers/ville-manninen.md
@@ -1,9 +1,0 @@
----
-name: Ville Manninen
-title: Organizer
-location: Finland
-id: ville-manninen
-twitter: vvmann
-image: https://pbs.twimg.com/profile_images/566205097441370112/hyXCgkLC.jpeg
-email:
----

--- a/_organizers/ville-marjusaari.md
+++ b/_organizers/ville-marjusaari.md
@@ -1,0 +1,9 @@
+---
+name: Ville Marjusaari
+title: Organizer
+location: Finland
+id: ville-marjusaari
+twitter: marjusaari
+image: https://pbs.twimg.com/profile_images/667266006180478976/r1cAoyst.jpg
+email:
+---

--- a/_participants/adria-fontcuberta-aymerich.md
+++ b/_participants/adria-fontcuberta-aymerich.md
@@ -1,8 +1,0 @@
----
-name: Adrià Fontcuberta Aymerich
-keynote: false
-id: adria-fontcuberta-aymerich
-twitter: afontcu
-image: https://pbs.twimg.com/profile_images/683678286375960576/Oz_kJySv_400x400.jpg
----
-text here

--- a/_participants/antti-mustonen.md
+++ b/_participants/antti-mustonen.md
@@ -1,8 +1,0 @@
----
-name: Antti Mustonen
-keynote: false
-id: antti-mustonen
-twitter:
-image:
----
-text here

--- a/_participants/anupam-arohi.md
+++ b/_participants/anupam-arohi.md
@@ -1,8 +1,0 @@
----
-name: Anupam Arohi
-keynote: false
-id: anupam-arohi
-twitter: anupam_arohi
-image: https://pbs.twimg.com/profile_images/722132234812022784/tRY6Lcew_400x400.jpg
----
-text here

--- a/_participants/ari-pekka-lappi.md
+++ b/_participants/ari-pekka-lappi.md
@@ -1,8 +1,0 @@
----
-name: Ari-Pekka Lappi
-keynote: false
-id: ari-pekka-lappi
-twitter: ilmirajat
-image: https://pbs.twimg.com/profile_images/461827507180670976/Swx122Dc_400x400.png 
----
-text here

--- a/_participants/ari-tikka.md
+++ b/_participants/ari-tikka.md
@@ -1,8 +1,0 @@
----
-name: Ari Tikka
-keynote: false
-id: ari-tikka
-twitter: aritikka
-image: https://pbs.twimg.com/profile_images/656904204473143297/d-wWOw85_400x400.jpg
----
-text here

--- a/_participants/diana-larsen.md
+++ b/_participants/diana-larsen.md
@@ -1,8 +1,0 @@
----
-name: Diana Larsen
-keynote: false
-id: diana-larsen
-twitter: DianaOfPortland
-image: https://pbs.twimg.com/profile_images/496500632660893697/rYAuO2dU_400x400.jpeg
----
-text here

--- a/_participants/eliina-vornanen.md
+++ b/_participants/eliina-vornanen.md
@@ -1,8 +1,0 @@
----
-name: Eliina Vornanen
-keynote: false
-id: eliina-vornanen
-twitter: ElluVor
-image:
----
-text here

--- a/_participants/erwann-cleudic.md
+++ b/_participants/erwann-cleudic.md
@@ -1,8 +1,0 @@
----
-name: Erwann Cleudic
-keynote: false
-id: erwann-cleudic
-twitter: 
-image:
----
-text here

--- a/_participants/geoffrey-bache.md
+++ b/_participants/geoffrey-bache.md
@@ -1,8 +1,0 @@
----
-name: Geoffrey Bache
-keynote: false
-id: geoffrey-bache
-twitter: 
-image:
----
-text here

--- a/_participants/heikki-lahtela.md
+++ b/_participants/heikki-lahtela.md
@@ -1,8 +1,0 @@
----
-name: Heikki Lahtela
-keynote: false
-id: heikki-lahtela
-twitter: taikahessu
-image: https://pbs.twimg.com/profile_images/722700274700300288/rJib6LXg_400x400.jpg
----
-text here

--- a/_participants/henri-karhatsu.md
+++ b/_participants/henri-karhatsu.md
@@ -1,8 +1,0 @@
----
-name: Henri Karhatsu
-keynote: false
-id: henri-karhatsu
-twitter: karhatsu
-image: https://pbs.twimg.com/profile_images/531847207448621056/L2cVO1IC.jpeg
----
-text here

--- a/_participants/jani-roman.md
+++ b/_participants/jani-roman.md
@@ -1,8 +1,0 @@
----
-name: Jani Roman
-keynote: false
-id: jani-roman
-twitter:
-image:
----
-text here

--- a/_participants/jordi-medina-fruitos.md
+++ b/_participants/jordi-medina-fruitos.md
@@ -1,8 +1,0 @@
----
-name: Jordi Medina Fruitós
-keynote: false
-id: jordi-medina-fruitos
-twitter: jmedinafruitos
-image: https://pbs.twimg.com/profile_images/378800000837653956/f2d2231883e0150e9b8e0228f2a2b073_400x400.jpeg
----
-text here

--- a/_participants/juha-heimonen.md
+++ b/_participants/juha-heimonen.md
@@ -1,8 +1,0 @@
----
-name: Juha Heimonen
-keynote: false
-id: juha-heimonen
-twitter: evilbubu
-image: https://pbs.twimg.com/profile_images/709454034965549056/J--UGcKV_400x400.jpg 
----
-text here

--- a/_participants/juho-vepsalainen.md
+++ b/_participants/juho-vepsalainen.md
@@ -1,8 +1,0 @@
----
-name: Juho Vepsäläinen
-keynote: false
-id: juho-vepsalainen
-twitter: bebraw
-image: https://pbs.twimg.com/profile_images/697785480126062593/6VhYKSAW_400x400.jpg
----
-text here

--- a/_participants/jukka-isosomppi.md
+++ b/_participants/jukka-isosomppi.md
@@ -1,8 +1,0 @@
----
-name: Jukka Isosomppi
-keynote: false
-id: jukka-isosomppi
-twitter: 
-image:
----
-text here

--- a/_participants/jussi-sjoberg.md
+++ b/_participants/jussi-sjoberg.md
@@ -1,7 +1,0 @@
----
-name: Jussi Sjöberg
-id: jussi-sjoberg
-twitter: sootti
-image: https://pbs.twimg.com/profile_images/416013718/omakuva_kivetys_400x400.jpg
----
-text here

--- a/_participants/jyrki-puttonen.md
+++ b/_participants/jyrki-puttonen.md
@@ -1,8 +1,0 @@
----
-name: Jyrki Puttonen
-keynote: false
-id: jyrki-puttonen
-twitter: jyrkiput
-image: https://pbs.twimg.com/profile_images/524372310/profile_pic_400x400.jpg
----
-text here

--- a/_participants/katariina-laakkonen.md
+++ b/_participants/katariina-laakkonen.md
@@ -1,8 +1,0 @@
----
-name: Katariina Laakkonen
-keynote: false
-id: katariina-laakkonen
-twitter:
-image:
----
-text here

--- a/_participants/kristo-mikko-daniel.md
+++ b/_participants/kristo-mikko-daniel.md
@@ -1,8 +1,0 @@
----
-name: Kristo-Mikko Daniel
-keynote: true
-id: kristo-mikko-daniel
-twitter: DiverKMD
-image: https://pbs.twimg.com/profile_images/605312748268838912/rHCT9F1Y.jpg
----
-text here

--- a/_participants/llewellyn-falco.md
+++ b/_participants/llewellyn-falco.md
@@ -1,6 +1,0 @@
----
-name: Llewellyn Falco
-id: llewellyn-falco
-twitter: LlewellynFalco
-image: https://pbs.twimg.com/profile_images/1837642393/twitter_profile.png
----

--- a/_participants/maaret-pyhajarvi.md
+++ b/_participants/maaret-pyhajarvi.md
@@ -1,6 +1,0 @@
----
-name: Maaret Pyhäjärvi
-id: maaret-pyhajarvi
-twitter: maaretp
-image: https://pbs.twimg.com/profile_images/629062251152961536/kumhZ5lm_400x400.jpg
----

--- a/_participants/matti-kinnunen.md
+++ b/_participants/matti-kinnunen.md
@@ -1,8 +1,0 @@
----
-name: Matti Kinnunen
-keynote: false
-id: matti-kinnunen
-twitter: manethemean
-image: https://abs.twimg.com/sticky/default_profile_images/default_profile_2_400x400.png
----
-text here

--- a/_participants/miika-kuha.md
+++ b/_participants/miika-kuha.md
@@ -1,8 +1,0 @@
----
-name: Miika Kuha
-keynote: false
-id: miika-kuha
-twitter: kuha
-image: https://pbs.twimg.com/profile_images/61157946/kuha_400x400.png
----
-text here

--- a/_participants/mika-pyrhonen.md
+++ b/_participants/mika-pyrhonen.md
@@ -1,8 +1,0 @@
----
-name: Mika Pyrhönen
-keynote: false
-id: mika-pyrhonen
-twitter:
-image:
----
-text here

--- a/_participants/niina-nieminen.md
+++ b/_participants/niina-nieminen.md
@@ -1,8 +1,0 @@
----
-name: Niina Nieminen
-keynote: false
-id: niina-nieminen
-twitter: NieminenNiina
-image: https://pbs.twimg.com/profile_images/722377122572926976/FNSDntO4_400x400.jpg
----
-text here

--- a/_participants/simo-routarinne.md
+++ b/_participants/simo-routarinne.md
@@ -1,8 +1,0 @@
----
-name: Simo Routarinne
-keynote: false
-id: simo-routarinne
-twitter:
-image: 
----
-text here

--- a/_participants/soile-sainio.md
+++ b/_participants/soile-sainio.md
@@ -1,8 +1,0 @@
----
-name: Soile Sainio
-keynote: false
-id: soile-sainio
-twitter: Soikkis
-image: https://pbs.twimg.com/profile_images/378800000380708216/f64f03f730a6ceddec02dd00f3230aae_400x400.jpeg
----
-text here

--- a/_participants/tero-kadenius.md
+++ b/_participants/tero-kadenius.md
@@ -1,8 +1,0 @@
----
-name: Tero Kadenius
-keynote: false
-id: tero-kadenius
-twitter: Pisketti
-image: https://pbs.twimg.com/profile_images/455089814329499649/4iMP4CDs_400x400.jpeg 
----
-text here

--- a/_participants/tuomas-heroja.md
+++ b/_participants/tuomas-heroja.md
@@ -1,8 +1,0 @@
----
-name: Tuomas Heroja
-keynote: false
-id: tuomas-heroja
-twitter: tuomasheroja
-image: https://abs.twimg.com/sticky/default_profile_images/default_profile_3_400x400.png
----
-text here

--- a/_participants/tuomas-jokinen.md
+++ b/_participants/tuomas-jokinen.md
@@ -1,8 +1,0 @@
----
-name: Tuomas Jokine
-keynote: false
-id: tuomas-jokinen
-twitter:
-image:
----
-text here

--- a/_participants/veli-pekka-eloranta.md
+++ b/_participants/veli-pekka-eloranta.md
@@ -1,6 +1,0 @@
----
-name: Veli-Pekka Eloranta
-id: Veli-Pekka Eloranta
-twitter: weellu
-image: https://pbs.twimg.com/profile_images/1334749986/13e00be1-a043-4b19-981a-da2e3bf6c8f4_400x400.jpg
----

--- a/_participants/ville-reijonen.md
+++ b/_participants/ville-reijonen.md
@@ -1,7 +1,0 @@
----
-name: Ville Reijonen
-id: ville-reijonen
-twitter: vreijone
-image: https://pbs.twimg.com/profile_images/467924887395266560/70AB94Kx.jpeg
----
-text here

--- a/_sections/about.md
+++ b/_sections/about.md
@@ -13,5 +13,5 @@ The event takes place 7.- 9.9.2018. The price of attendance is basically room an
 
 We will open the registration during Spring 2018. There will be a limited amount of places: around 40. 
 
-If you are interested in joining ACCFI 2018, join our mailing list by submitting your email address below to get updates on when the registration opens.
+If you are interested in joining ACCFI 2018, join [our mailing list here](https://groups.google.com/forum/#!forum/accfi-2018-news/join) to get updates on when the registration opens.
 

--- a/_sections/about.md
+++ b/_sections/about.md
@@ -9,8 +9,9 @@ Agile Coach Camp Finland is a **weekend retreat** of brilliant, curious minds sh
 
 We give space for great things to emerge for people who help others get better in their thinking and doing - such as agile coaches / scrum masters, organizational / business coaches, consultants, tech coaches / seniors - to share in the form of an open space. *You* are welcome to join us for in-depth discussions about developing software, people and organizations. You can try out new ideas, facilitation techniques, games, practice programming with katas and dojos, get advice on a burning problem of yours or even jam with a guitar, do yoga, or go on a hike together.
 
-On Friday, we spend the day with **pre-scheduled workshop topics**. Full Saturday and Sunday morning until midday we run an open space conference, facilitated by Diana Larsen, Antti Kirjavainen and Karoliina Luoto. It's not all work, we'll make sure there's sessions that take you from head space to physical space too.
+The event takes place 7.- 9.9.2018. The price of attendance is basically room and board for the length of the coaching camp and will be less than 400€. 
 
-The event takes place 20.-22.5.2016 and location is  [Herrankukkaro](http://herrankukkaro.visualizer360.com/panorama). The tickets include a ride from Turku to Herrankukkaro.
+We will open the registration during Spring 2018. There will be a limited amount of places: around 40. 
 
-Follow [@agilefinland](https://twitter.com/agilefinland) for [#accfi](https://twitter.com/hashtag/ACCFI?src=hash) on twitter to stay tuned on the news.
+If you are interested in joining ACCFI 2018, join our mailing list by submitting your email address below to get updates on when the registration opens.
+

--- a/_sections/participants.md
+++ b/_sections/participants.md
@@ -1,5 +1,6 @@
 ---
 order_no: 21
+hide: true
 title: "Participants"
 ---
 

--- a/_sections/price.md
+++ b/_sections/price.md
@@ -1,5 +1,6 @@
 ---
 order_no: 12
+hide: true
 about: about
 contained: true
 title: Price

--- a/_sections/schedule.md
+++ b/_sections/schedule.md
@@ -2,6 +2,7 @@
 order_no: 19
 about: "schedule"
 contained: true
+hide: true
 title: "Schedule outline"
 ---
 

--- a/_sections/sponsors.md
+++ b/_sections/sponsors.md
@@ -1,5 +1,6 @@
 ---
 order_no: 113
+hide: true
 about: sponsor-block
 title: Sponsors
 ---

--- a/_sections/venue.md
+++ b/_sections/venue.md
@@ -1,6 +1,7 @@
 ---
 order_no: 13
 about: about
+hide: true
 contained: true
 title: Herrankukkaro
 ---

--- a/_sections/what_is_accfi.md
+++ b/_sections/what_is_accfi.md
@@ -11,13 +11,14 @@ title: What is ACCFI?
 </div>
 <div class="one-third">
   <h4>When</h4>
-  May 20, 21, 22<br/>
+  September 7, 8, 9<br/>
   <img src="/images/friday_saturday_sunday.png"/>
 </div>
 <div class="one-third">
 
   <h4>Where</h4>
-  Herrankukkaro<br/>
-  <img src="http://lh3.googleusercontent.com/-YI2RvckU094/S8LKYflx_gI/AAAAAAAAK5w/aabvHVYGPx4WTbI_9yrEXClN55tXN6OfwCCo/s800/HK_yleis_kes%25C3%25A4%2B%2528411%2529.jpg"/>
+  Beautiful, scenic<br/>
+  location near Helsinki<br/>
+  to be unveiled!<br/>
 
 </div>

--- a/styles/_snippets/_navigation.scss
+++ b/styles/_snippets/_navigation.scss
@@ -51,7 +51,7 @@
     text-align: center;
     position: relative;
     margin-bottom: 25px;
-    padding-top: 150px; 
+    padding-top: 200px; 
 
 }
 

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -63,7 +63,7 @@ body
     background: rgba($shark, 0.1);
 
     font-family: 'Source Sans Pro', sans-serif;
-    font-size: 14px;
+    font-size: 22px;
     color: $main-text-color;
     padding: 0;
     margin: 0;


### PR DESCRIPTION
* Hide schedule, prices, venue, participants.
* Remove 2016 organizers, all participants (current organizers left).
* Change font size to bigger.
* Changed event name in text from Agile Coaching Camp to Agile Coach Camp.